### PR TITLE
Add uglify-js as a dev dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ NODE_PATH := $(MAKEFILE_PATH)test,$(MAKEFILE_PATH):$(NODE_PATH)
 REPORTER ?= spec
 MOCHA ?= ./node_modules/.bin/mocha
 BROWSERIFY = ./node_modules/.bin/browserify
+UGLIFYJS = ./node_modules/.bin/uglifyjs
 FLAGS = -t uglifyify
+
 
 all: community-translator.js community-translator.min.js community-translator.css
 
@@ -15,7 +17,7 @@ browserify:
 	$(BROWSERIFY) $(FLAGS) lib/index.js --standalone communityTranslator -o community-translator.js
 
 uglifyjs:
-	uglifyjs community-translator.js -c > community-translator.min.js
+	$(UGLIFYJS) community-translator.js -c > community-translator.min.js
 
 community-translator.css: css/custom.css
 	cat css/jquery.webui*.css css/custom.css > community-translator.css

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ It does so by providing on-screen translation ability, so that the community can
 ### Build
 To create the `community-translator.js` and `community-translator.css` files which should be loaded in the translatable site.
 
-* Make sure you've got uglifyjs installed in system. If not, run `sudo npm install -g uglify-js`
 * run `npm install`
 * run `make`.
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"chai": "^2.1.2",
 		"jsdom": "^2.0.0",
 		"mocha": "*",
+		"uglify-js": "*",
 		"uglifyify": "*"
 	},
 	"license": "GPL-2.0+",


### PR DESCRIPTION
We're using uglify-js in our make, so we should pull it down and not make the user install it manually.

This PR conflicts with the docs updates in #3, but we just need to remove the global install line from the README.md once they've both landed.
