### PR TITLE
Upgrade debug dependency to v2.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	"keywords": [],
 	"dependencies": {
 		"JSON2": "*",
-		"debug": "1.0.1",
+		"debug": ">=2.6.9",
 		"jed": "*"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Resolves https://nvd.nist.gov/vuln/detail/CVE-2017-16137

> It takes around 50k characters to block for 2 seconds making this a low severity issue.

> The debug module is vulnerable to regular expression denial of service when untrusted user input is passed into the o formatter. 

The debug api we use is unchanged, so this should be safe.