### PR TITLE
WIP: Build with webpack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,22 +2,16 @@ MAKEFILE_PATH := $(dir $(lastword $(MAKEFILE_LIST)))
 NODE_PATH := $(MAKEFILE_PATH)test,$(MAKEFILE_PATH):$(NODE_PATH)
 REPORTER ?= spec
 MOCHA ?= ./node_modules/.bin/mocha
-BROWSERIFY = ./node_modules/.bin/browserify
-UGLIFYJS = ./node_modules/.bin/uglifyjs
-FLAGS = -t uglifyify
-
+WEBPACK = ./node_modules/.bin/webpack
+DEV_FLAGS = --config webpack.dev.config.js
 
 all: community-translator.js community-translator.min.js community-translator.css
 
-community-translator.js: browserify
+community-translator.js:
+	$(WEBPACK) $(DEV_FLAGS)
 
-community-translator.min.js: uglifyjs
-
-browserify:
-	$(BROWSERIFY) $(FLAGS) lib/index.js --standalone communityTranslator -o community-translator.js
-
-uglifyjs:
-	$(UGLIFYJS) community-translator.js -c > community-translator.min.js
+community-translator.min.js:
+	$(WEBPACK)
 
 community-translator.css: css/custom.css
 	cat css/jquery.webui*.css css/custom.css > community-translator.css

--- a/package.json
+++ b/package.json
@@ -14,13 +14,12 @@
 	},
 	"devDependencies": {
 		"better-assert": "*",
-		"browserify": "*",
 		"chai": "^2.1.2",
 		"jquery": "^3.3.1",
 		"jsdom": "^11.6.2",
 		"mocha": "*",
-		"uglify-js": "*",
-		"uglifyify": "*"
+		"webpack": "^4.31.0",
+		"webpack-cli": "^3.3.2"
 	},
 	"license": "GPL-2.0+",
 	"scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,10 @@
+const path = require('path');
+
+module.exports = {
+  mode: 'production',
+  entry: './lib/index.js',
+  output: {
+	path: path.resolve( __dirname ),
+    filename: 'community-translator.min.js'
+  },
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,8 @@ module.exports = {
   mode: 'production',
   entry: './lib/index.js',
   output: {
+	library: 'communityTranslator',
+	libraryTarget: 'umd',
 	path: path.resolve( __dirname ),
     filename: 'community-translator.min.js'
   },

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -4,6 +4,8 @@ module.exports = {
   mode: 'development',
   entry: './lib/index.js',
   output: {
+	library: 'communityTranslator',
+	libraryTarget: 'umd',
 	path: path.resolve( __dirname ),
     filename: 'community-translator.js'
   },

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,0 +1,10 @@
+const path = require('path');
+
+module.exports = {
+  mode: 'development',
+  entry: './lib/index.js',
+  output: {
+	path: path.resolve( __dirname ),
+    filename: 'community-translator.js'
+  },
+};


### PR DESCRIPTION
This PR updates the makefile to use webpack instead of uglify.

I was looking at deploying #9, but ran into issues with `uglify` and es6:

``` ~/a8c/community-translator (master) $ make
./node_modules/.bin/browserify -t uglifyify lib/index.js --standalone communityTranslator -o community-translator.js
./node_modules/.bin/uglifyjs community-translator.js -c > community-translator.min.js
Parse error at community-translator.js:181,1
	const c = 'color: ' + this.color;
	^
ERROR: Unexpected token: keyword «const»
    at JS_Parse_Error.get (eval at <anonymous> (/Users/jules/a8c/community-translator/node_modules/uglify-js/tools/node.js:20:1), <anonymous>:71:23)
    at fatal (/Users/jules/a8c/community-translator/node_modules/uglify-js/bin/uglifyjs:298:27)
    at run (/Users/jules/a8c/community-translator/node_modules/uglify-js/bin/uglifyjs:241:9)
    at Object.<anonymous> (/Users/jules/a8c/community-translator/node_modules/uglify-js/bin/uglifyjs:167:5)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
make: *** [uglifyjs] Error 1
```

Browserify has a transform for this: [varify](https://www.npmjs.com/package/varify), but it failed silently, so I decided to just switch to webpack instead.

It turns out webpack includes the `terser-webpack-plugin` by default in it's production mode, and it produces a slightly smaller file than uglify:

```
$ ls -l community-translator*.min.js
-rw-r--r-- 1 jules staff 52406 May 17 15:48 community-translator.uglify.min.js
-rw-r--r-- 1 jules staff 49926 May 17 19:38 community-translator.min.js
```

TODO: I still need to confirm that the UMD configuration from webpack matches up with uglify's `--standalone` option for our purposes.